### PR TITLE
Removed stuff now handled by spatie/laravel-json-api-paginate

### DIFF
--- a/src/Traits/HandlesPagination.php
+++ b/src/Traits/HandlesPagination.php
@@ -47,9 +47,7 @@ trait HandlesPagination
         app(Dispatcher::class)->dispatch(new Filtered($query, $request));
 
         $paginateMethod = config('json-api-paginate.method_name', 'jsonPaginate');
-        /** @var LengthAwarePaginator $paginator */
-        $paginator = $query->{$paginateMethod}();
 
-        return $paginator;
+        return $query->{$paginateMethod}();
     }
 }

--- a/src/Traits/HandlesPagination.php
+++ b/src/Traits/HandlesPagination.php
@@ -19,15 +19,6 @@ trait HandlesPagination
     protected function mutateQueryForPagination(&$query, Request $request): LengthAwarePaginator
     {
         $pagination = $request->pagination();
-        $model = $query->getModel();
-
-        $size = $pagination->size($model->getPerPage());
-
-        $query->limit($size);
-
-        if ($number = $pagination->number()) {
-            $query->offset($number * $size);
-        }
 
         if ($sort = $pagination->sort()) {
             $query->orders = [];
@@ -58,14 +49,6 @@ trait HandlesPagination
         $paginateMethod = config('json-api-paginate.method_name', 'jsonPaginate');
         /** @var LengthAwarePaginator $paginator */
         $paginator = $query->{$paginateMethod}();
-
-        if ($sort) {
-            $paginator->appends('sort', $this->request->query('sort'));
-        }
-
-        if ($filter) {
-            $paginator->appends('filter', $this->request->query('filter'));
-        }
 
         return $paginator;
     }

--- a/tests/migrations/2017_02_22_000000_dummies_table.php
+++ b/tests/migrations/2017_02_22_000000_dummies_table.php
@@ -11,6 +11,7 @@ class DummiesTable extends Migration
         Schema::create('dummies', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->unsignedInteger('relation_id')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
The `paginator->append` stuff is handled by Spatie (everything except the page number is copied to the paginator) and doing the `limit` and `offset` stuff ourself probably interferes with higher page numbers, no ?

Please check this before merging.