### PR TITLE
Added Support for Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "require": {
         "php": ">=7.1.0",
         "tobscure/json-api": "^0.3.0",
-        "illuminate/routing": "5.4.* || 5.5.*",
-        "illuminate/database": "5.4.* || 5.5.*",
+        "illuminate/routing": "5.4.* || 5.5.* || 5.6.*",
+        "illuminate/database": "5.4.* || 5.5.* || 5.6.*",
         "spatie/laravel-json-api-paginate": "1.*"
     },
     "autoload-dev": {


### PR DESCRIPTION
This is needed by flagrow.io to successfully upgrade to L5.6.